### PR TITLE
Updates

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -5,9 +5,10 @@ NAMESPACE := "$NAMESPACE"
 HF_TOKEN := "$HF_TOKEN"
 GH_TOKEN := "$GH_TOKEN"
 
-#MODEL := "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct"
 MODEL := "deepseek-ai/DeepSeek-R1-0528"
+#MODEL := "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct"
 #MODEL := "Qwen/Qwen3-235B-A22B-FP8"
+#MODEL := "Qwen/Qwen3-30B-A3B-FP8"
 
 KN := "kubectl -n $NAMESPACE"
 

--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,7 @@ GH_TOKEN := "$GH_TOKEN"
 
 #MODEL := "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct"
 MODEL := "deepseek-ai/DeepSeek-R1-0528"
+#MODEL := "Qwen/Qwen3-235B-A22B-FP8"
 
 KN := "kubectl -n $NAMESPACE"
 

--- a/Justfile.remote
+++ b/Justfile.remote
@@ -19,6 +19,7 @@ benchmark RR NUM_REQUESTS INPUT_LEN OUTPUT_LEN:
         --num-prompts {{NUM_REQUESTS}} \
         --ignore-eos
 
+# For hitting an individual vLLM instance while deploying a P/D setup
 benchmark_no_pd POD_IP RR NUM_REQUESTS INPUT_LEN OUTPUT_LEN:
     python vllm/benchmarks/benchmark_serving.py \
         --base-url http://{{POD_IP}}:8000 \
@@ -30,3 +31,14 @@ benchmark_no_pd POD_IP RR NUM_REQUESTS INPUT_LEN OUTPUT_LEN:
         --seed $(date +%M%H%M%S) \
         --num-prompts {{NUM_REQUESTS}} \
         --ignore-eos
+
+# For vLLM PyTorch traces.
+# vLLM serve must be run with the VLLM_TORCH_PROFILER_DIR env set.
+start_profile:
+  curl -X POST {{BASE_URL}}/start_profile
+stop_profile:
+  curl -X POST {{BASE_URL}}/stop_profile
+profile:
+  just start_profile \
+  && sleep 1 \
+  && just stop_profile

--- a/install-scripts/common.sh
+++ b/install-scripts/common.sh
@@ -22,7 +22,7 @@ export TORCH_CUDA_ARCH_LIST="9.0a+PTX"
 banner() { printf '\n========== %s ==========\n' "$*"; }
 
 # Re-usable “uv pip install” wrapper (adds --no-cache-dir by default)
-upip() { "${UV}" pip install --python "${PYTHON}" --no-progress --no-cache-dir "$@"; }
+upip() { "${UV}" pip install --python "${PYTHON}" --no-progress --no-cache-dir --torch-backend=auto "$@"; }
 
 # Clone the repo if missing, otherwise fast-forward to the requested branch
 clone_or_update() {

--- a/lws.yaml
+++ b/lws.yaml
@@ -24,12 +24,21 @@ spec:
               - name: vllm-worker
                 image: "quay.io/tms/vllm-dev-deepep:0.1.0"
                 imagePullPolicy: Always
-                workingDir: /app
+                workingDir: /code
                 stdin: true
                 tty: true
                 command: ["/bin/sh","-c"]
                 args:
                   - |
+                    #################
+                    # Interactive section
+                    #################
+                    # export VENV_PATH="/code/venv"
+                    # source /init-scripts/common.sh
+                    # /init-scripts/dotfiles.sh
+                    # sleep infinity
+                    #################
+                    #
                     #################
                     # Install vLLM
                     #################
@@ -54,7 +63,7 @@ spec:
                         --data-parallel-rpc-port 5555 \
                         --data-parallel-start-rank $START_RANK \
                         --trust-remote-code \
-                        --enforce-eager
+                        --load-format dummy
                     else
                       #################
                       # Worker-only launch
@@ -71,29 +80,31 @@ spec:
                         --data-parallel-rpc-port 5555 \
                         --data-parallel-start-rank $START_RANK \
                         --trust-remote-code \
-                        --enforce-eager \
+                        --load-format dummy \
                         --headless
                     fi
                 env:
-                  - name: CUDA_LAUNCH_BLOCKING
+                  - name: VLLM_TORCH_PROFILER_DIR
+                    value: "/code/traces"
+                  - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
                     value: "1"
                   - name: DP_SIZE
-                    value: "4"
+                    value: "16"
                   - name: TP_SIZE
                     value: "1"
                   - name: DP_SIZE_LOCAL
-                    value: "2"
+                    value: "8"
                   - name: VLLM_REPO_URL
                     value: "https://github.com/vllm-project/vllm.git"
                   - name: VLLM_BRANCH
                     value: "main"
-                  #- name: VLLM_USE_DEEP_GEMM
-                  #  value: "1"
+                  - name: VLLM_USE_DEEP_GEMM
+                    value: "1"
                   - name: VLLM_ALL2ALL_BACKEND
                   #  value: "naive"
-                    value: "pplx"
+                  #  value: "pplx"
                   #  value: "deepep_high_throughput"
-                  #  value: "deepep_low_latency"
+                    value: "deepep_low_latency"
                   # Needed for GDRCOPY to be used.
                   # See: https://github.com/NVIDIA/nvidia-container-toolkit/releases/tag/v1.15.0
                   - name: NVIDIA_GDRCOPY
@@ -145,15 +156,15 @@ spec:
                     - "SYS_RAWIO"
                 resources:
                   limits:
-                    memory: 64Gi
+                    memory: 512Gi
                     ephemeral-storage: 64Gi
-                    nvidia.com/gpu: "2"
+                    nvidia.com/gpu: "8"
                     rdma/ib: 1
                   requests:
-                    cpu: 16
-                    memory: 64Gi
+                    cpu: 32
+                    memory: 512Gi
                     ephemeral-storage: 64Gi 
-                    nvidia.com/gpu: "2"
+                    nvidia.com/gpu: "8"
                     rdma/ib: 1
                 volumeMounts:
                   - name: dshm

--- a/lws.yaml
+++ b/lws.yaml
@@ -62,8 +62,7 @@ spec:
                         --data-parallel-address $(LWS_LEADER_ADDRESS) \
                         --data-parallel-rpc-port 5555 \
                         --data-parallel-start-rank $START_RANK \
-                        --trust-remote-code \
-                        --load-format dummy
+                        --trust-remote-code
                     else
                       #################
                       # Worker-only launch
@@ -80,7 +79,6 @@ spec:
                         --data-parallel-rpc-port 5555 \
                         --data-parallel-start-rank $START_RANK \
                         --trust-remote-code \
-                        --load-format dummy \
                         --headless
                     fi
                 env:
@@ -95,7 +93,7 @@ spec:
                   - name: DP_SIZE_LOCAL
                     value: "8"
                   - name: VLLM_REPO_URL
-                    value: "https://github.com/vllm-project/vllm.git"
+                    value: "https://github.com/tlrmchlsmth/vllm.git"
                   - name: VLLM_BRANCH
                     value: "main"
                   - name: VLLM_USE_DEEP_GEMM
@@ -124,6 +122,8 @@ spec:
                     value: "eth0"
                   - name: NCCL_SOCKET_IFNAME
                     value: "eth0"
+                  #- name: NCCL_DEBUG
+                  #  value: "info"
                   - name: NCCL_IB_HCA
                     value: "ibp"
                   - name: VLLM_LOGGING_LEVEL

--- a/lws.yaml
+++ b/lws.yaml
@@ -93,7 +93,7 @@ spec:
                   - name: DP_SIZE_LOCAL
                     value: "8"
                   - name: VLLM_REPO_URL
-                    value: "https://github.com/tlrmchlsmth/vllm.git"
+                    value: "https://github.com/vllm-project/vllm.git"
                   - name: VLLM_BRANCH
                     value: "main"
                   - name: VLLM_USE_DEEP_GEMM

--- a/vllm-builder.yaml
+++ b/vllm-builder.yaml
@@ -31,8 +31,17 @@ spec:
         VLLM_SOURCE_DIR="/code/vllm" \
           clone_or_update "${VLLM_REPO_URL}" "${VLLM_SOURCE_DIR}" "${VLLM_BRANCH}"
 
-        CCACHE_DIR=/code/ccache \
-          /init-scripts/vllm.sh
+        pushd "${VLLM_SOURCE_DIR}" >/dev/null
+        CCACHE_DIR="/code/ccache" \
+        CCACHE_NOHASHDIR="true"   \
+          "${UV}" pip install -e \
+                 --python "${PYTHON}" \
+                 --no-progress \
+                 --no-cache-dir \
+                 --no-build-isolation \
+                 .
+
+        popd >/dev/null
     env:
       - name: VLLM_REPO_URL
         value: "https://github.com/vllm-project/vllm.git"

--- a/vllm-builder.yaml
+++ b/vllm-builder.yaml
@@ -44,9 +44,9 @@ spec:
         popd >/dev/null
     env:
       - name: VLLM_REPO_URL
-        value: "https://github.com/neuralmagic/vllm.git"
+        value: "https://github.com/vllm-project/vllm.git"
       - name: VLLM_BRANCH
-        value: "varun/deepseek-decode-opt"
+        value: "main"
 
       - name: HF_HUB_CACHE
         value: /huggingface-cache
@@ -90,5 +90,5 @@ spec:
         claimName: tms-hf-cache
     - name: vllm
       persistentVolumeClaim:
-        claimName: tms-vllm-2
+        claimName: tms-vllm
   restartPolicy: Never

--- a/vllm-builder.yaml
+++ b/vllm-builder.yaml
@@ -28,25 +28,25 @@ spec:
         mkdir -p /code/ccache
 
         source /init-scripts/common.sh
-        VLLM_SOURCE_DIR="/code/vllm" \
-          clone_or_update "${VLLM_REPO_URL}" "${VLLM_SOURCE_DIR}" "${VLLM_BRANCH}"
+        export VLLM_SOURCE_DIR="/code/vllm"
+        clone_or_update "${VLLM_REPO_URL}" "${VLLM_SOURCE_DIR}" "${VLLM_BRANCH}"
 
         pushd "${VLLM_SOURCE_DIR}" >/dev/null
         CCACHE_DIR="/code/ccache" \
         CCACHE_NOHASHDIR="true"   \
-          "${UV}" pip install -e \
+          "${UV}" pip install \
                  --python "${PYTHON}" \
                  --no-progress \
                  --no-cache-dir \
                  --no-build-isolation \
-                 .
+                 -e .
 
         popd >/dev/null
     env:
       - name: VLLM_REPO_URL
-        value: "https://github.com/vllm-project/vllm.git"
+        value: "https://github.com/neuralmagic/vllm.git"
       - name: VLLM_BRANCH
-        value: "main"
+        value: "varun/deepseek-decode-opt"
 
       - name: HF_HUB_CACHE
         value: /huggingface-cache
@@ -90,5 +90,5 @@ spec:
         claimName: tms-hf-cache
     - name: vllm
       persistentVolumeClaim:
-        claimName: tms-vllm 
+        claimName: tms-vllm-2
   restartPolicy: Never


### PR DESCRIPTION
- Add ability to profile vLLM (pytorch profiles will be stored in `/code/traces` in the `tms-vllm` PVC
- Switch to use the DeepGEMM LL kernels - this fixes an issue with a mismatch between the vLLM image and All2All kernels
- Update the deployment to serve DeepSeekR1 in a 2-node setup